### PR TITLE
fix dashboard workflow

### DIFF
--- a/.github/workflows/add-to-dashboard.yml
+++ b/.github/workflows/add-to-dashboard.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name == 'issues'
     steps:
       - name: Add Issue to Dashboard
-        uses: leonsteinhaeuser/repo_name-beta-automations@v1.2.1
+        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
         with:
           gh_token: ${{ secrets.MY_GITHUB_TOKEN }}
           organization: catalystneuro


### PR DESCRIPTION
Looks like cookiecutter had an error with the name of the workflow here so stuff wasn't getting added to the common CatalystNeuro TODO list