### PR TITLE
Update metadata extraction with optogenetic metadata

### DIFF
--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/convert_session.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/convert_session.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
         "/Volumes/T7/CatalystNeuro/NWB/Datta/dopamine-reinforces-spontaneous-behavior/dlight_raw_data/dlight_photometry_processed_full.parquet"
     )
     metadata_path = Path(
-        "/Volumes/T7/CatalystNeuro/NWB/Datta/dopamine-reinforces-spontaneous-behavior/dlight_raw_data/session_metadata.yaml"
+        "/Volumes/T7/CatalystNeuro/NWB/Datta/dopamine-reinforces-spontaneous-behavior/metadata/reinforcement_photometry_metadata.yaml"
     )
     output_dir_path = Path("/Volumes/T7/CatalystNeuro/NWB/Datta/conversion_nwb/")
     shutil.rmtree(output_dir_path)

--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/fiberphotometryinterface.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/fiberphotometryinterface.py
@@ -52,8 +52,8 @@ class FiberPhotometryInterface(BaseDataInterface):
         metadata["NWBFile"]["identifier"] = self.source_data["session_uuid"]
         metadata["NWBFile"]["session_id"] = self.source_data["session_uuid"]
         metadata["Subject"]["subject_id"] = session_metadata["subject_id"]
-        metadata["Subject"]["sex"] = "U"
-        metadata["FiberPhotometry"]["area"] = session_metadata["area"]
+        metadata["Subject"]["sex"] = session_metadata["sex"]
+        metadata["FiberPhotometry"]["area"] = session_metadata["photometry_area"]
         metadata["FiberPhotometry"]["reference_max"] = session_metadata["reference_max"]
         metadata["FiberPhotometry"]["signal_max"] = session_metadata["signal_max"]
         metadata["FiberPhotometry"]["signal_reference_corr"] = session_metadata["signal_reference_corr"]

--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/preconversion/extract_metadata.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/preconversion/extract_metadata.py
@@ -169,6 +169,11 @@ def extract_reinforcement_metadata(
             metadata[uuid]["sex"] = "F"
         else:
             metadata[uuid]["sex"] = "U"
+        # add si units to names
+        metadata[uuid]["stim_duration_s"] = metadata[uuid].pop("stim_duration")
+        metadata[uuid]["stim_frequency_Hz"] = metadata[uuid].pop("stim_frequency")
+        metadata[uuid]["pulse_width_s"] = metadata[uuid].pop("pulse_width")
+        metadata[uuid]["power_watts"] = metadata[uuid].pop("power") / 1000
         if i >= num_sessions:
             break
 

--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/preconversion/extract_metadata.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/preconversion/extract_metadata.py
@@ -12,6 +12,25 @@ from neuroconv.utils import dict_deep_update
 def extract_photometry_metadata(
     data_path: str, example_uuid: str = None, num_sessions: int = None, reinforcement_photometry: bool = False
 ) -> dict:
+    """Extract metadata from photometry data.
+
+    Parameters
+    ----------
+    data_path : str
+        Path to data.
+    example_uuid : str, optional
+        UUID of example session to extract metadata from.
+    num_sessions : int, optional
+        Number of sessions to extract metadata from.
+    reinforcement_photometry : bool, optional
+        If True, extract metadata from reinforcement photometry sessions. If False, extract metadata from
+        non-reinforcement photometry sessions.
+
+    Returns
+    -------
+    metadata : dict
+        Dictionary of metadata.
+    """
     photometry_data_path = Path(data_path) / "dlight_raw_data/dlight_photometry_processed_full.parquet"
     columns = (
         "uuid",
@@ -73,6 +92,25 @@ def extract_photometry_metadata(
 def extract_reinforcement_metadata(
     data_path: str, example_uuid: str = None, num_sessions: int = None, reinforcement_photometry: bool = False
 ) -> dict:
+    """Extract metadata from reinforcement data.
+
+    Parameters
+    ----------
+    data_path : str
+        Path to data.
+    example_uuid : str, optional
+        UUID of example session to extract metadata from.
+    num_sessions : int, optional
+        Number of sessions to extract metadata from.
+    reinforcement_photometry : bool, optional
+        If True, extract metadata from reinforcement photometry sessions. If False, extract metadata from
+        non-photometry reinforcement sessions.
+
+    Returns
+    -------
+    metadata : dict
+        Dictionary of metadata.
+    """
     reinforcement_data_path = Path(data_path) / "optoda_raw_data/closed_loop_behavior.parquet"
     columns = (
         "uuid",
@@ -134,6 +172,22 @@ def extract_reinforcement_metadata(
 def extract_reinforcement_photometry_metadata(
     data_path: str, example_uuid: str = None, num_sessions: int = None
 ) -> dict:
+    """Extract metadata from reinforcement photometry data.
+
+    Parameters
+    ----------
+    data_path : str
+        Path to data.
+    example_uuid : str, optional
+        UUID of example session to extract metadata from.
+    num_sessions : int, optional
+        Number of sessions to extract metadata from.
+
+    Returns
+    -------
+    metadata : dict
+        Dictionary of metadata.
+    """
     photometry_metadata = extract_photometry_metadata(
         data_path, example_uuid, num_sessions, reinforcement_photometry=True
     )

--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/preconversion/extract_metadata.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/preconversion/extract_metadata.py
@@ -6,12 +6,8 @@ import yaml
 from tqdm import tqdm
 import pytz
 
-# NWB Ecosystem
-from neuroconv.utils import load_dict_from_file
 
-
-def extract_metadata(data_path: str, metadata_path: str, example_uuid: str = None):
-    timezone = pytz.timezone("America/New_York")
+def extract_photometry_metadata(data_path: str, example_uuid: str = None) -> dict:
     columns = (
         "uuid",
         "session_name",
@@ -41,30 +37,51 @@ def extract_metadata(data_path: str, metadata_path: str, example_uuid: str = Non
         uuids = {example_uuid}
     metadata = {}
     for uuid in tqdm(uuids):
-        session_df = pd.read_parquet(
-            data_path,
-            columns=columns,
-            filters=[("uuid", "==", uuid)],
-        )
-        metadata[uuid] = {}
-        for col in metadata_columns:
-            first_notnull = session_df.loc[session_df[col].notnull(), col].iloc[0]
-            if isinstance(first_notnull, np.float64):  # numpy scalars aren't serializable
-                first_notnull = first_notnull.item()
-            metadata[uuid][col] = first_notnull
-        session_name = set(session_df.session_name[session_df.session_name.notnull()]) | set(
-            session_df.SessionName[session_df.SessionName.notnull()]
-        )
-        assert len(session_name) <= 1, "Multiple session names found"
-        try:
-            metadata[uuid]["session_description"] = session_name.pop()
-        except KeyError:  # No session name found
-            metadata[uuid]["session_description"] = ""
-        date = timezone.localize(metadata[uuid].pop("date"))
-        metadata[uuid]["session_start_time"] = date.isoformat()
-        metadata[uuid]["subject_id"] = metadata[uuid].pop("mouse_id")
-    with open(metadata_path, "w") as f:
-        yaml.dump(metadata, f)
+        extract_session_metadata(columns, data_path, metadata, metadata_columns, uuid)
+        metadata[uuid]["photometry_area"] = metadata[uuid].pop("area")
+
+    return metadata
+
+
+def extract_session_metadata(columns, data_path, metadata, metadata_columns, uuid):
+    """Extract metadata from a single session specified by uuid.
+
+    Parameters
+    ----------
+    columns : tuple
+        Columns to load from the parquet file.
+    data_path : str
+        Path to the parquet file.
+    metadata : dict
+        Dictionary to store the metadata in (edited in-place).
+    metadata_columns : tuple
+        Columns to extract metadata from.
+    uuid : str
+        UUID of the session to extract metadata from.
+    """
+    timezone = pytz.timezone("America/New_York")
+    session_df = pd.read_parquet(
+        data_path,
+        columns=columns,
+        filters=[("uuid", "==", uuid)],
+    )
+    metadata[uuid] = {}
+    for col in metadata_columns:
+        first_notnull = session_df.loc[session_df[col].notnull(), col].iloc[0]
+        if isinstance(first_notnull, np.float64):  # numpy scalars aren't serializable
+            first_notnull = first_notnull.item()
+        metadata[uuid][col] = first_notnull
+    session_name = set(session_df.session_name[session_df.session_name.notnull()]) | set(
+        session_df.SessionName[session_df.SessionName.notnull()]
+    )
+    assert len(session_name) <= 1, "Multiple session names found"
+    try:
+        metadata[uuid]["session_description"] = session_name.pop()
+    except KeyError:  # No session name found
+        metadata[uuid]["session_description"] = ""
+    date = timezone.localize(metadata[uuid].pop("date"))
+    metadata[uuid]["session_start_time"] = date.isoformat()
+    metadata[uuid]["subject_id"] = metadata[uuid].pop("mouse_id")
 
 
 if __name__ == "__main__":
@@ -75,4 +92,6 @@ if __name__ == "__main__":
         "/Volumes/T7/CatalystNeuro/NWB/Datta/dopamine-reinforces-spontaneous-behavior/dlight_raw_data/session_metadata.yaml"
     )
     example_uuid = "2891f649-4fbd-4119-a807-b8ef507edfab"
-    extract_metadata(data_path, metadata_path, example_uuid)
+    metadata = extract_photometry_metadata(data_path, example_uuid)
+    with open(metadata_path, "w") as f:
+        yaml.dump(metadata, f)

--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/preconversion/extract_metadata.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/preconversion/extract_metadata.py
@@ -163,6 +163,12 @@ def extract_reinforcement_metadata(
     for i, uuid in enumerate(tqdm(uuids)):
         extract_session_metadata(columns, reinforcement_data_path, metadata, metadata_columns, uuid)
         metadata[uuid]["optogenetic_area"] = metadata[uuid].pop("area")
+        if metadata[uuid]["sex"] == "male":
+            metadata[uuid]["sex"] = "M"
+        elif metadata[uuid]["sex"] == "female":
+            metadata[uuid]["sex"] = "F"
+        else:
+            metadata[uuid]["sex"] = "U"
         if i >= num_sessions:
             break
 

--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/preconversion/extract_metadata.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/preconversion/extract_metadata.py
@@ -10,7 +10,7 @@ import pytz
 from neuroconv.utils import load_dict_from_file
 
 
-def extract_metadata(data_path: str, metadata_path: str):
+def extract_metadata(data_path: str, metadata_path: str, example_uuid: str = None):
     timezone = pytz.timezone("America/New_York")
     columns = (
         "uuid",
@@ -33,9 +33,12 @@ def extract_metadata(data_path: str, metadata_path: str):
         "snr",
         "area",
     )
-    uuid_df = pd.read_parquet(data_path, columns=["uuid"])
-    uuids = set(uuid_df.uuid[uuid_df.uuid.notnull()])
-    del uuid_df
+    if example_uuid is None:
+        uuid_df = pd.read_parquet(data_path, columns=["uuid"])
+        uuids = set(uuid_df.uuid[uuid_df.uuid.notnull()])
+        del uuid_df
+    else:
+        uuids = {example_uuid}
     metadata = {}
     for uuid in tqdm(uuids):
         session_df = pd.read_parquet(
@@ -71,6 +74,5 @@ if __name__ == "__main__":
     metadata_path = Path(
         "/Volumes/T7/CatalystNeuro/NWB/Datta/dopamine-reinforces-spontaneous-behavior/dlight_raw_data/session_metadata.yaml"
     )
-    extract_metadata(data_path, metadata_path)
-    metadata = load_dict_from_file(metadata_path)
-    print(metadata)
+    example_uuid = "2891f649-4fbd-4119-a807-b8ef507edfab"
+    extract_metadata(data_path, metadata_path, example_uuid)


### PR DESCRIPTION
Fixes #29 

Also, reorganizes metadata extraction by experiment type (photometry-only, reinforcement-only, reinforcement+photometry, etc.)