### PR TITLE
Fix installation tests

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Test module load
       uses: jannekem/run-python-script-action@v1
       with:
-        script: import {{cookiecutter.repo_name_slug}}
+        script: import datta_lab_to_nwb


### PR DESCRIPTION
We semi-regularly test if packages like this are installable, but the CI had a bug from the cookiecutter, which I believe has been fixed