### PR TITLE
Target syllable for Optogenetic Interface

### DIFF
--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/basedattainterface.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/basedattainterface.py
@@ -17,11 +17,6 @@ class BaseDattaInterface(BaseDataInterface):
         metadata["NWBFile"]["session_start_time"] = session_metadata["session_start_time"]
         metadata["NWBFile"]["identifier"] = self.source_data["session_uuid"]
         metadata["NWBFile"]["session_id"] = self.source_data["session_uuid"]
-        if "trigger_syllable_scalar_comparison" in session_metadata.keys():
-            if session_metadata["trigger_syllable_scalar_comparison"] == "lt":
-                metadata["NWBFile"]["stimulus_notes"] = "Stim Down: Stimulate when target velocity <25th percentile"
-            elif session_metadata["trigger_syllable_scalar_comparison"] == "gt":
-                metadata["NWBFile"]["stimulus_notes"] = "Stim Up: Stimulate when target velocity >75th percentile"
 
         metadata["Subject"] = {}
         metadata["Subject"]["subject_id"] = session_metadata["subject_id"]

--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/convert_session.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/convert_session.py
@@ -122,8 +122,8 @@ def session_to_nwb(
 if __name__ == "__main__":
     # Parameters for conversion
     processed_path = Path("/Volumes/T7/CatalystNeuro/NWB/Datta/dopamine-reinforces-spontaneous-behavior")
-    # raw_path = Path("/Volumes/T7/CatalystNeuro/NWB/Datta/xtra_raw/session_20210215162554-455929")
-    raw_path = Path("/Volumes/T7/CatalystNeuro/NWB/Datta/xtra_raw/velocity_modulation")
+    raw_path = Path("/Volumes/T7/CatalystNeuro/NWB/Datta/xtra_raw/session_20210215162554-455929")
+    # raw_path = Path("/Volumes/T7/CatalystNeuro/NWB/Datta/xtra_raw/velocity_modulation")
     output_dir_path = Path("/Volumes/T7/CatalystNeuro/NWB/Datta/conversion_nwb/")
     if output_dir_path.exists():
         shutil.rmtree(
@@ -160,14 +160,14 @@ if __name__ == "__main__":
     raw_fp_example = "b814a426-7ec9-440e-baaa-105ba27a5fa6"
     velocity_modulation_example = "c621e134-50ec-4e8b-8175-a8c023d92789"
     session_to_nwb(
-        session_id=velocity_modulation_example,
+        session_id=raw_fp_example,
         processed_path=processed_path,
         raw_path=raw_path,
         output_dir_path=output_dir_path,
-        experiment_type="velocity_modulation",
+        experiment_type="reinforcement_photometry",
         stub_test=stub_test,
     )
-    with NWBHDF5IO(output_dir_path / f"{velocity_modulation_example}.nwb", "r") as io:
+    with NWBHDF5IO(output_dir_path / f"{raw_fp_example}.nwb", "r") as io:
         nwbfile = io.read()
         print(nwbfile)
     # nwbfile_path = output_dir_path / f"{figure1d_example}.nwb"

--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/optogeneticinterface.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/optogeneticinterface.py
@@ -46,6 +46,7 @@ class OptogeneticInterface(BaseDattaInterface):
         metadata["Optogenetics"]["stim_duration_s"] = session_metadata["stim_duration_s"]
         metadata["Optogenetics"]["power_watts"] = session_metadata["power_watts"]
         metadata["Optogenetics"]["area"] = subject_metadata["optogenetic_area"]
+        metadata["Optogenetics"]["target_syllable"] = session_metadata["target_syllable"]
         if "velocity_modulation" in session_metadata.keys():
             if session_metadata["trigger_syllable_scalar_comparison"] == "lt":
                 stimulus_notes = "Stim Down: Stimulate when target velocity <25th percentile"
@@ -64,6 +65,8 @@ class OptogeneticInterface(BaseDattaInterface):
                 "stim_frequency_Hz": {"type": "number"},
                 "stim_duration_s": {"type": "number"},
                 "power_watts": {"type": "number"},
+                "pulse_width_s": {"type": "number"},
+                "target_syllable": {"type": "number"},
             },
         }
         return metadata_schema
@@ -92,9 +95,12 @@ class OptogeneticInterface(BaseDattaInterface):
             data, timestamps = self.reconstruct_cts_stim(metadata, session_df)
         else:  # pulsed stim
             data, timestamps = self.reconstruct_pulsed_stim(metadata, session_df)
+        id2sorted_index = metadata["BehavioralSyllable"]["id2sorted_index"]
+        target_syllable = id2sorted_index[metadata["Optogenetics"]["target_syllable"]]
         ogen_series = OptogeneticSeries(
             name="OptogeneticSeries",
             description="Onset of optogenetic stimulation is recorded as a 1, and offset is recorded as a 0.",
+            comments=f"target_syllable = {target_syllable}",
             site=ogen_site,
             data=H5DataIO(data, compression=True),
             timestamps=H5DataIO(timestamps, compression=True),

--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/optogeneticinterface.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/optogeneticinterface.py
@@ -49,10 +49,9 @@ class OptogeneticInterface(BaseDattaInterface):
         metadata["Optogenetics"]["target_syllable"] = session_metadata["target_syllable"]
         if "velocity_modulation" in session_metadata.keys():
             if session_metadata["trigger_syllable_scalar_comparison"] == "lt":
-                stimulus_notes = "Stim Down: Stimulate when target velocity <25th percentile"
+                metadata["NWBFile"]["stimulus_notes"] = "Stim Down: Stimulate when target velocity <25th percentile"
             elif session_metadata["trigger_syllable_scalar_comparison"] == "gt":
-                stimulus_notes = "Stim Up: Stimulate when target velocity >75th percentile"
-        metadata["NWBFile"]["stimulus_notes"] = stimulus_notes
+                metadata["NWBFile"]["stimulus_notes"] = "Stim Up: Stimulate when target velocity >75th percentile"
 
         return metadata
 

--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/preconversion/extract_metadata.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/preconversion/extract_metadata.py
@@ -127,6 +127,7 @@ def extract_reinforcement_metadata(
         "stim_frequency",
         "pulse_width",
         "power",
+        "target_syllable",
     )
     subject_columns = (
         "mouse_id",
@@ -209,7 +210,7 @@ def extract_velocity_modulation_metadata(
         "date",
         "mouse_id",
         "stim_duration",
-        "trigger_syllable",
+        "target_syllable",
         "trigger_syllable_scalar_threshold",
         "trigger_syllable_scalar_comparison",
     )


### PR DESCRIPTION
Fixes #66 

`target_syllable` is added as a comment on the optogenetic series.  This allows using the syllable_id2sorted_index mapping from the metadata.yaml file.