### PR TITLE
Switch keypoint timestamps to rate

### DIFF
--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/rawfiberphotometryinterface.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023/rawfiberphotometryinterface.py
@@ -175,10 +175,20 @@ class RawFiberPhotometryInterface(BaseDattaInterface):
             coordinates=(0.260, 2.550, -2.40),  # (AP, ML, DV)
         )
 
+        keypoint_sessions = [
+            "keypoint-dls-dlight-9",
+            "keypoint-dls-dlight-10",
+            "keypoint-dls-dlight-11",
+            "keypoint-dls-dlight-12",
+            "keypoint-dls-dlight-13",
+        ]
         skip = (
             self.source_data["tdt_path"] is None
             or not Path(self.source_data["tdt_path"]).exists()
-            or not (Path(self.source_data["tdt_path"]).parent / "alignment_df.parquet").exists()
+            or (
+                not (Path(self.source_data["tdt_path"]).parent / "alignment_df.parquet").exists()
+                and self.source_data["session_id"] not in keypoint_sessions
+            )
         )
         if skip:
             excitation_sources_table.add_row(peak_wavelength=470.0, source_type="LED")

--- a/src/datta_lab_to_nwb/markowitz_gillis_nature_2023_keypoint/keypointinterface.py
+++ b/src/datta_lab_to_nwb/markowitz_gillis_nature_2023_keypoint/keypointinterface.py
@@ -50,7 +50,6 @@ class KeypointInterface(BaseDattaInterface):
         SAMPLING_RATE = metadata["Constants"]["VIDEO_SAMPLING_RATE"]
         keypoint_dict = joblib.load(self.source_data["file_path"])
         raw_keypoints = keypoint_dict["positions_median"]
-        timestamps = H5DataIO(np.arange(raw_keypoints.shape[0]) / SAMPLING_RATE, compression=True)
 
         index_to_name = metadata["Keypoint"]["index_to_name"]
         camera_names = ["bottom", "side1", "side2", "side3", "side4", "top"]  # as confirmed by email with authors
@@ -64,7 +63,7 @@ class KeypointInterface(BaseDattaInterface):
                 name=keypoint_name,
                 description=f"Keypoint corresponding to {keypoint_name}",
                 data=H5DataIO(raw_keypoints[:, keypoint_index, :], compression=True),
-                timestamps=timestamps,
+                rate=SAMPLING_RATE,
                 unit="mm",
                 reference_frame=metadata["Keypoint"]["reference_frame"],
             )


### PR DESCRIPTION
Fixes #109

Also noticed a bug with the raw fiber photometry interface that was skipping the keypoints, so I fixed that.

The processed photometry and raw photometry timestamps may be regular for some sessions but they are irregular for others, so I left those as is.